### PR TITLE
rollback name to sinatra given this fork does not change the gem 

### DIFF
--- a/sinatra.gemspec
+++ b/sinatra.gemspec
@@ -1,7 +1,7 @@
 $LOAD_PATH.unshift File.expand_path('../lib', __FILE__)
 require 'sinatra/version'
 
-Gem::Specification.new 'sinatra-acd', Sinatra::VERSION do |s|
+Gem::Specification.new 'sinatra', Sinatra::VERSION do |s|
   s.description       = "Sinatra is a DSL for quickly creating web applications in Ruby with minimal effort."
   s.summary           = "Classy web-development dressed in a DSL"
   s.authors           = ["Blake Mizerany", "Ryan Tomayko", "Simon Rozet", "Konstantin Haase"]


### PR DESCRIPTION
There was a commit who introduced a different name [change](https://github.com/acdcorp/sinatra/commit/115945144171ccb1d0dce2d046b604bf375331cd) for this gem.

Normally public gems or forks are not renamed. There are some situations where the fork becomes relevant or/and differs a lot from original repo even with new features or specific problems solved that it is more convenient to have a new gem for the specific functionality however, I did not find any relevant change or difference between this and the original repo beside the old commits of this fork. 

My suggestion is to keep the same name in order to avoid issues with `gem install`or  `bundle install` or if you prefer to rename it, please update the `gemspec` file with the correct name and update all bundler dependencies.

This pull request prevents to have in a Gemfile due to the mentioned [change] (https://github.com/acdcorp/sinatra/commit/115945144171ccb1d0dce2d046b604bf375331cd) the following patch

```ruby
gem 'sinatra-acd', github: 'acdcorp/sinatra'
```

or that bundler raise the following error:

```ruby
can't find sinatra gem in https://github.com/acdcorp/sinatra.git
```